### PR TITLE
Add fixtures module helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,36 @@ Other common environment variables:
 * `BEAKER_HYPERVISOR` defaults to `docker`, can be set to `vagrant_libvirt`
 * `BEAKER_destroy` can be set to `no` to avoid destroying the box after completion. Useful to inspect failures
 * `BEAKER_provision` can be set to `no` to reuse a box. Note that the box must exist already. See `BEAKER_destroy`
+
+# Modules
+
+## Metadata
+
+By default the module uses [beaker-module_install_helper](https://github.com/puppetlabs/beaker-module_install_helper). Its approach is copying the module and then install every dependency as listed in the module's metadata.json. This is a slow process and if the latest modules aren't accepted, it can lead to problems.
+
+```ruby
+# This is the default
+configure_beaker(modules: :metadata)
+```
+
+## Fixtures
+
+An alternative is to use the fixtures:
+
+```ruby
+configure_beaker(modules: :fixtures)
+```
+
+This will switch to use [puppet-modulebuilder](https://github.com/puppetlabs/puppet-modulebuilder) on all modules present in `spec/fixtures/modules`. This is faster, but more importantly it also allows using git versions of modules. No dependency resolution is done and it is up to the module developer to ensure it's a correct set. It is also up to the module developer to ensure the fixtures are checked out before beaker runs.
+
+```ruby
+# In Rakefile
+task :beaker => "spec_prep"
+```
+
+## None
+
+It's also possible to skip module installation altogether, giving the module developer complete freedom to handle this.
+```ruby
+configure_beaker(modules: nil)
+```

--- a/lib/voxpupuli/acceptance/fixtures.rb
+++ b/lib/voxpupuli/acceptance/fixtures.rb
@@ -1,0 +1,143 @@
+require 'tmpdir'
+require 'puppet/modulebuilder'
+
+module Voxpupupli
+  module Acceptance
+    class Fixtures
+      class << self
+        # Install fixture modules on the given hosts
+        #
+        # @param [Host, Array<Host>, String, Symbol] hosts
+        #   The beaker hosts to run on
+        # @param [Array<String>, String] modulepath
+        #   A modulepath as Puppet uses it. Typically spec/fixtures/modules
+        # @param [Logger, nil] logger
+        #   An optional logger
+        def install_fixture_modules_on(hosts, modulepath, logger = nil)
+          Dir.mktmpdir do |destination|
+            modules = build_modules(modulepath, destination, logger)
+
+            install_modules_on(hosts, modules, logger)
+          end
+
+          nil
+        end
+
+        # Build modules in the given sources.
+        #
+        # @param [Array<String>, String] modulepath
+        #   A modulepath as Puppet uses it
+        # @param [String] destination
+        #   The target directory to build modules into
+        # @param [Logger, nil] logger
+        #   An optional logger
+        #
+        # @return [Hash<String=>String>]
+        #   A mapping of module names and the path to their tarball
+        def build_modules(modulepath, destination, logger = nil)
+          modulepath = [modulepath] if modulepath.is_a?(String)
+
+          modules = {}
+
+          modulepath.each do |dir|
+            Dir[File.join(dir, '*', 'metadata.json')].each do |metadata|
+              path = File.dirname(metadata)
+              name = File.basename(path)
+              next if modules.include?(name)
+
+              builder = Puppet::Modulebuilder::Builder.new(File.realpath(path), destination, logger)
+
+              unless valid_directory_name?(name, builder.metadata['name'])
+                warning = "Directory name of #{path} doesn't match metadata name #{builder.metadata['name']}"
+                if logger
+                  logger.warn(warning)
+                else
+                  STDERR.puts(warning)
+                end
+              end
+
+              modules[name] = builder.build
+            end
+          end
+
+          modules
+        end
+
+        # Install modules on a number of hosts
+        #
+        # This is done by iterating over every host. On that host a temporary
+        # directory is created. Each module is copied there and installed by
+        # force.
+        #
+        # @param [Host, Array<Host>, String, Symbol] hosts
+        #   The beaker hosts to run on
+        # @param [Hash<String=>String>] modules
+        #   A mapping between module names and their tarball
+        # @param [Logger, nil] logger
+        #   An optional logger
+        def install_modules_on(hosts, modules, logger = nil)
+          hosts.each do |host|
+            logger.debug("Installing modules on #{host}") if logger
+
+            temp_dir_on(host) do |target_dir|
+              modules.each do |name, source_path|
+                target_file = File.join(target_dir, File.basename(source_path))
+                logger.debug("Copying module #{name} from #{source_path} to #{target_file}") if logger
+
+                scp_to(host, source_path, target_file)
+                on host, puppet("module install --force --ignore-dependencies '#{target_file}'")
+              end
+            end
+          end
+
+          nil
+        end
+
+        # Create a temporay directory on the host, similar to Dir.mktmpdir but
+        # on a remote host.
+        #
+        # @example
+        #   temp_dir_on(host) { |dir| puts dir }
+        #
+        # @param [Host, String, Symbol] host
+        #   The beaker host to run on
+        def temp_dir_on(host, &block)
+          result = on host, "mktemp -d"
+          raise "Could not create directory" unless result.success?
+
+          dir = result.stdout.strip
+
+          begin
+            yield dir
+          ensure
+            on host, "rm -rf #{dir}"
+          end
+
+          nil
+        end
+
+        # Validate a directory name matches its metadata name.
+        #
+        # This is useful to detect misconfigurations in fixture set ups.
+        #
+        # @example
+        #   assert valid_directory_name?('tftp', 'theforeman-tftp')
+        # @example
+        #   refute valid_directory_name?('puppet-tftp', 'theforeman-tftp')
+        #
+        # @param [String] directory_name
+        #   Name of the directory. Not the full path
+        # @param [String] metadata_name
+        #   Name as it shows up in the metadata. It is normalized and accepts
+        #   both / and - as separators.
+        #
+        # @return [Boolean] Wether the directory name is valid with the given
+        #   metadata name
+        def valid_directory_name?(directory_name, metadata_name)
+          normalized = metadata_name.tr('/', '-').split('-').last
+          normalized == directory_name
+        end
+      end
+    end
+  end
+end

--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker-rspec'
   s.add_runtime_dependency 'beaker-vagrant'
   s.add_runtime_dependency 'ed25519'
+  s.add_runtime_dependency 'puppet-modulebuilder', '~> 0.1'
   s.add_runtime_dependency 'rbnacl', '>= 4'
   s.add_runtime_dependency 'rbnacl-libsodium'
   s.add_runtime_dependency 'serverspec'


### PR DESCRIPTION
This copies the approach taken by litmus and builds every module in fixtures. Those are then installed on the target system. This has the benefit that it's much faster since there's no more reliance on the Puppet forge. It's also more flexible since you can use git versions in fixtures.

However, it is a major difference and can give different results. The beaker task itself also doesn't depend on spec_prep and that part is missing. That's why it's an option. It also implements the `nil` option to not set up any modules.

Ideally we'd depend on a released version of https://github.com/puppetlabs/puppet-modulebuilder/pull/15 to reduce the size of the tarball.