### PR TITLE
Add support to store environment variables as facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,7 @@ require 'voxpupuli/acceptance/spec_helper'
 configure_beaker
 ```
 
-It is also possible to do per host configuration
-
-```ruby
-require 'voxpupuli/acceptance/spec_helper_acceptance'
-
-configure_beaker do |host|
-  if fact_on(host, 'os.name') == 'CentOS'
-    install_package(host, 'epel-release')
-  end
-end
-```
+# Running tests
 
 This module provides no rake helpers but leaves that to [puppetlabs_spec_helper](https://github.com/puppetlabs/puppetlabs_spec_helper). Commonly invoked as:
 
@@ -46,9 +36,31 @@ Other common environment variables:
 * `BEAKER_destroy` can be set to `no` to avoid destroying the box after completion. Useful to inspect failures
 * `BEAKER_provision` can be set to `no` to reuse a box. Note that the box must exist already. See `BEAKER_destroy`
 
-# Modules
+Since it's still plain [RSpec](https://rspec.info/), it is also possible to call an individual test file:
 
-## Metadata
+```bash
+BEAKER_setfile=centos7-64 bundle exec rspec spec/acceptance/my_test.rb
+```
+
+# Customizing host configuration
+
+## Per host configuration
+
+It is also possible to do per host configuration by providing a block:
+
+```ruby
+require 'voxpupuli/acceptance/spec_helper_acceptance'
+
+configure_beaker do |host|
+  if fact_on(host, 'os.name') == 'CentOS'
+    install_package(host, 'epel-release')
+  end
+end
+```
+
+## Installing Puppet Modules
+
+### Metadata
 
 By default the module uses [beaker-module_install_helper](https://github.com/puppetlabs/beaker-module_install_helper). Its approach is copying the module and then install every dependency as listed in the module's metadata.json. This is a slow process and if the latest modules aren't accepted, it can lead to problems.
 
@@ -57,7 +69,7 @@ By default the module uses [beaker-module_install_helper](https://github.com/pup
 configure_beaker(modules: :metadata)
 ```
 
-## Fixtures
+### Fixtures
 
 An alternative is to use the fixtures:
 
@@ -72,7 +84,7 @@ This will switch to use [puppet-modulebuilder](https://github.com/puppetlabs/pup
 task :beaker => "spec_prep"
 ```
 
-## None
+### None
 
 It's also possible to skip module installation altogether, giving the module developer complete freedom to handle this.
 ```ruby

--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -1,4 +1,31 @@
-def configure_beaker(modules: :metadata, &block)
+ENV_VAR_PREFIX = 'BEAKER_FACTER_'
+FACT_FILE = '/etc/facter/facts.d/voxpupuli-acceptance-env.json'
+
+def beaker_facts_from_env
+  facts = {}
+
+  ENV.each do |var, value|
+    next unless var.start_with?(ENV_VAR_PREFIX)
+
+    fact = var.sub(ENV_VAR_PREFIX, '').downcase
+    facts[fact] = value
+  end
+
+  facts
+end
+
+def write_beaker_facts_on(hosts)
+  beaker_facts = beaker_facts_from_env
+
+  if beaker_facts.any?
+    require 'json'
+    on(hosts, "mkdir -p #{File.dirname(FACT_FILE)} && cat <<VOXPUPULI_BEAKER_ENV_VARS > #{FACT_FILE}\n#{beaker_facts.to_json}\nVOXPUPULI_BEAKER_ENV_VARS")
+  else
+    on(hosts, "rm -f #{FACT_FILE}")
+  end
+end
+
+def configure_beaker(modules: :metadata, configure_facts_from_env: true, &block)
   ENV['PUPPET_INSTALL_TYPE'] ||= 'agent'
   ENV['BEAKER_PUPPET_COLLECTION'] ||= 'puppet6'
   ENV['BEAKER_debug'] ||= 'true'
@@ -32,6 +59,8 @@ def configure_beaker(modules: :metadata, &block)
         fixture_modules = File.join(Dir.pwd, 'spec', 'fixtures', 'modules')
         Voxpupupli::Acceptance::Fixtures.install_fixture_modules_on(hosts, fixture_modules)
       end
+
+      write_beaker_facts_on(hosts) if configure_facts_from_env
 
       if block
         hosts.each do |host|


### PR DESCRIPTION
This code converts `BEAKER_FACTER_*` env vars to facts on target machines. This allows testing variations. While this is similar to tiers, it's not really the same. For example, a tier can be single node vs multi node, but those can both be run with multiple versions.

Inspired by https://github.com/voxpupuli/puppet-hyperglass/pull/15#discussion_r497724556