### PR TITLE
Use released github_changelog_generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :release do
-  gem 'github_changelog_generator', require: false, git: 'https://github.com/voxpupuli/github-changelog-generator', branch: 'voxpupuli_essential_fixes'
+  gem 'github_changelog_generator', '~> 1.16', require: false
 end


### PR DESCRIPTION
This includes all fixes we need and removes the need for a git version.