### PR TITLE
Add shared examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,35 @@ RSpec.configure do |c|
   ]
 end
 ```
+
+## Shared examples
+
+Some [RSpec shared examples](https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples) are shipped by default. These make it easier to write tests.
+
+### An idempotent resource
+
+Often you want to test some manifest is idempotent. This means applying a manifest and ensuring there are no failures. It then applies again and ensures no changes were made.
+
+```ruby
+describe 'myclass' do
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      include myclass
+      PUPPET
+    end
+  end
+end
+```
+
+### Examples
+
+In modules there's the convention to have an examples directory. It's actually great to test these in acceptance. For this a shared example is available:
+
+```ruby
+describe 'my example' do
+  it_behaves_like 'the example', 'my_example.pp'
+end
+```
+
+For this `examples/my_example.pp' must exist and contain valid Puppet code. It then uses the idempotent resource shared example.

--- a/lib/voxpupuli/acceptance/examples.rb
+++ b/lib/voxpupuli/acceptance/examples.rb
@@ -1,0 +1,21 @@
+shared_examples 'an idempotent resource' do |host|
+  host ||= default
+
+  it 'applies with no errors' do
+    apply_manifest_on(host, manifest, catch_failures: true)
+  end
+
+  it 'applies a second time without changes' do
+    apply_manifest_on(host, manifest, catch_changes: true)
+  end
+end
+
+shared_examples 'the example' do |name, host|
+  include_examples 'an idempotent resource', host do
+    let(:manifest) do
+      path = File.join(Dir.pwd, 'examples', name)
+      raise Exception, "Example '#{path}' does not exist" unless File.exist?(path)
+      File.read(path)
+    end
+  end
+end

--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require_relative 'examples'
+
 ENV_VAR_PREFIX = 'BEAKER_FACTER_'
 FACT_FILE = '/etc/facter/facts.d/voxpupuli-acceptance-env.json'
 


### PR DESCRIPTION
These shared examples have been used in the Foreman project and have been copied to some Voxpupuli modules. Having these in voxpupuli-acceptance means there's less duplication and a central place to maintain them. It is also a place to document them.