### PR TITLE
Add a rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ configure_beaker
 
 # Running tests
 
-This module provides no rake helpers but leaves that to [puppetlabs_spec_helper](https://github.com/puppetlabs/puppetlabs_spec_helper). Commonly invoked as:
+This module provides rake helpers. It prefers [puppetlabs_spec_helper](https://github.com/puppetlabs/puppetlabs_spec_helper) but falls back to [beaker-rspec](https://github.com/voxpupuli/beaker-rspec). Commonly invoked as:
+
+To do so, in your `Rakefile`
+
+```ruby
+require 'voxpupuli/acceptance/rake'
+```
+
+It can then be invoked as:
 
 ```bash
 BEAKER_setfile=centos7-64 bundle exec rake beaker

--- a/lib/voxpupuli/acceptance/rake.rb
+++ b/lib/voxpupuli/acceptance/rake.rb
@@ -1,0 +1,5 @@
+begin
+  require 'puppetlabs_spec_helper/tasks/beaker'
+rescue LoadError
+  require 'beaker-rspec/rake_task'
+end

--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker-vagrant'
   s.add_runtime_dependency 'ed25519'
   s.add_runtime_dependency 'puppet-modulebuilder', '~> 0.1'
+  s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'rbnacl', '>= 4'
   s.add_runtime_dependency 'rbnacl-libsodium'
   s.add_runtime_dependency 'serverspec'


### PR DESCRIPTION
puppetlabs_spec_helper provides slightly more featureful rake tasks but beaker-rspec itself has a basic task in case puppetlabs_spec_helper is not present.

Note I have opened https://github.com/puppetlabs/puppetlabs_spec_helper/pull/338 to see if we can remove it there.