### PR TITLE
Change fact handling into a setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,13 @@ jobs:
       - name: Run tests
         run: bundle exec rake beaker
         working-directory: examples/${{ matrix.example }}
+
+  post:
+    needs:
+      - unit
+      - acceptance
+    runs-on: ubuntu-latest
+    name: All tests
+    steps:
+      - name: Completion
+        run: echo "All tests completed successfully"

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ If no environment variables are present, the file is removed. It is not possible
 This behavior can be disabled altogether:
 
 ```ruby
-configure_beaker(configure_facts_from_env: false)
+RSpec.configure do |c|
+  c.suite_configure_facts_from_env = false
+end
 ```
 
 ## Hiera

--- a/examples/defaults_facts/Gemfile
+++ b/examples/defaults_facts/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'voxpupuli-acceptance', path: '../..'

--- a/examples/defaults_facts/Rakefile
+++ b/examples/defaults_facts/Rakefile
@@ -1,0 +1,1 @@
+require 'voxpupuli/acceptance/rake'

--- a/examples/defaults_facts/manifests/init.pp
+++ b/examples/defaults_facts/manifests/init.pp
@@ -1,0 +1,6 @@
+class defaults_facts {
+  file { "/voxpupuli-acceptance-test":
+    ensure  => 'file',
+    content => "Current test: ${module_name}\nThe answer: ${facts['the_answer']}\n",
+  }
+}

--- a/examples/defaults_facts/metadata.json
+++ b/examples/defaults_facts/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "voxpupuli_acceptance_tests-defaults_facts",
+  "version": "0.0.1",
+  "author": "Vox Pupuli",
+  "license": "Apache-2.0",
+  "summary": "The voxpupuli-acceptance test suite defaults_facts",
+  "description": "DESCRIBE THE TEST SUITE HERE",
+  "source": "https://github.com/voxpupuli/voxpupuli-acceptance",
+  "project_page": "https://github.com/voxpupuli/voxpupuli-acceptance",
+  "issues_url": "https://github.com/voxpupuli/voxpupuli-acceptance/issues",
+  "dependencies": [],
+  "requirements": [],
+  "operatingsystem_support": []
+}

--- a/examples/defaults_facts/spec/acceptance/basic_spec.rb
+++ b/examples/defaults_facts/spec/acceptance/basic_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper_acceptance'
+
+describe 'Basic integration test' do
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) { 'include defaults_facts' }
+  end
+
+  describe file('/voxpupuli-acceptance-test') do
+    it { is_expected.to be_file }
+    its(:content) { is_expected.to eq("Current test: defaults_facts\nThe answer: 42\n") }
+  end
+end

--- a/examples/defaults_facts/spec/spec_helper_acceptance.rb
+++ b/examples/defaults_facts/spec/spec_helper_acceptance.rb
@@ -1,0 +1,5 @@
+require 'voxpupuli/acceptance/spec_helper_acceptance'
+
+ENV['BEAKER_FACTER_THE_ANSWER'] = '42'
+
+configure_beaker

--- a/lib/voxpupuli/acceptance/facts.rb
+++ b/lib/voxpupuli/acceptance/facts.rb
@@ -1,0 +1,34 @@
+module Voxpupuli
+  module Acceptance
+    class Facts
+      ENV_VAR_PREFIX = 'BEAKER_FACTER_'
+      FACT_FILE = '/etc/facter/facts.d/voxpupuli-acceptance-env.json'
+
+      class << self
+        def beaker_facts_from_env
+          facts = {}
+
+          ENV.each do |var, value|
+            next unless var.start_with?(ENV_VAR_PREFIX)
+
+            fact = var.sub(ENV_VAR_PREFIX, '').downcase
+            facts[fact] = value
+          end
+
+          facts
+        end
+
+        def write_beaker_facts_on(hosts)
+          beaker_facts = beaker_facts_from_env
+
+          if beaker_facts.any?
+            require 'json'
+            on(hosts, "mkdir -p #{File.dirname(FACT_FILE)} && cat <<VOXPUPULI_BEAKER_ENV_VARS > #{FACT_FILE}\n#{beaker_facts.to_json}\nVOXPUPULI_BEAKER_ENV_VARS")
+          else
+            on(hosts, "rm -f #{FACT_FILE}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -1,33 +1,6 @@
 require_relative 'examples'
 
-ENV_VAR_PREFIX = 'BEAKER_FACTER_'
-FACT_FILE = '/etc/facter/facts.d/voxpupuli-acceptance-env.json'
-
-def beaker_facts_from_env
-  facts = {}
-
-  ENV.each do |var, value|
-    next unless var.start_with?(ENV_VAR_PREFIX)
-
-    fact = var.sub(ENV_VAR_PREFIX, '').downcase
-    facts[fact] = value
-  end
-
-  facts
-end
-
-def write_beaker_facts_on(hosts)
-  beaker_facts = beaker_facts_from_env
-
-  if beaker_facts.any?
-    require 'json'
-    on(hosts, "mkdir -p #{File.dirname(FACT_FILE)} && cat <<VOXPUPULI_BEAKER_ENV_VARS > #{FACT_FILE}\n#{beaker_facts.to_json}\nVOXPUPULI_BEAKER_ENV_VARS")
-  else
-    on(hosts, "rm -f #{FACT_FILE}")
-  end
-end
-
-def configure_beaker(modules: :metadata, configure_facts_from_env: true, &block)
+def configure_beaker(modules: :metadata, &block)
   ENV['PUPPET_INSTALL_TYPE'] ||= 'agent'
   ENV['BEAKER_PUPPET_COLLECTION'] ||= 'puppet6'
   ENV['BEAKER_debug'] ||= 'true'
@@ -65,7 +38,10 @@ def configure_beaker(modules: :metadata, configure_facts_from_env: true, &block)
         Voxpupuli::Acceptance::Fixtures.install_fixture_modules_on(hosts, fixture_modules)
       end
 
-      write_beaker_facts_on(hosts) if configure_facts_from_env
+      if RSpec.configuration.suite_configure_facts_from_env
+        require_relative 'facts'
+        Voxpupuli::Acceptance::Facts.write_beaker_facts_on(hosts)
+      end
 
       if RSpec.configuration.suite_hiera?
         hiera_data_dir = RSpec.configuration.suite_hiera_data_dir
@@ -92,6 +68,9 @@ def configure_beaker(modules: :metadata, configure_facts_from_env: true, &block)
 end
 
 RSpec.configure do |c|
+  # Fact handling
+  c.add_setting :suite_configure_facts_from_env, default: true
+
   # Hiera settings
   c.add_setting :suite_hiera, default: true
   c.add_setting :suite_hiera_data_dir, default: File.join('spec', 'acceptance', 'hieradata')


### PR DESCRIPTION
This changes the behavior of fact handling. This makes it easier to change without calling configure_beaker. Doing so plays better with modulesync.

It also moves it into its own file. This keeps the global namespace cleaner.

In it is also a commit to add a post task to indicate all tests passed. This allows setting up branch protection and auto merging.