### PR TITLE
Fix applying spec/setup_acceptance_node.pp

### DIFF
--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -52,15 +52,13 @@ def configure_beaker(modules: :metadata, &block)
         end
       end
 
+      local_setup = RSpec.configuration.setup_acceptance_node
       hosts.each do |host|
-        if block
-          yield host
+        yield host if block
 
-          local_setup = RSpec.configuration.setup_acceptance_node
-          if local_setup && File.exist?(local_setup)
-            puts "Configuring #{host} by applying #{local_setup}"
-            apply_manifest_on(host, File.read(local_setup), catch_failures: true)
-          end
+        if local_setup && File.exist?(local_setup)
+          puts "Configuring #{host} by applying #{local_setup}"
+          apply_manifest_on(host, File.read(local_setup), catch_failures: true)
         end
       end
     end


### PR DESCRIPTION
When no block is passed to `configure_beaker`, we have no code to evaluate in the context of each host, but we still want to apply `spec/setup_acceptance_node.pp` if it exist.