### PR TITLE
Drop rbnacl-libsodium

### DIFF
--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-modulebuilder', '~> 0.1'
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'rbnacl', '>= 4'
-  s.add_runtime_dependency 'rbnacl-libsodium'
   s.add_runtime_dependency 'serverspec'
   s.add_runtime_dependency 'winrm'
 end


### PR DESCRIPTION
To quote the gem's homepage at https://github.com/RubyCrypto/rbnacl-libsodium

> DISCONTINUED
> THIS GEM HAS OFFICIALLY BEEN DISCONTINUED.
> Please use your operating system's package manager to install libsodium when using RbNaCl. For more information, see:
> https://github.com/crypto-rb/rbnacl/wiki/Installing-libsodium

I found this while trying to do some testing on a Windows 2016 host and investigating why rbnacl-libsodium wouldn't build.