### PR TITLE
Add puppetlabs_spec_helper 4 compatibility

### DIFF
--- a/lib/voxpupuli/acceptance/rake.rb
+++ b/lib/voxpupuli/acceptance/rake.rb
@@ -1,6 +1,9 @@
 begin
   # Fixtures can be needed because of spec_prep
+  # spec_prep taks is provided by puppetlabs_spec_helper
   require 'puppetlabs_spec_helper/tasks/fixtures'
 rescue LoadError
-  require 'beaker-rspec/rake_task'
+  # we only need that during CI, so we rescue the LoadError
 end
+# provides the beaker rake task
+require 'beaker-rspec/rake_task'

--- a/lib/voxpupuli/acceptance/rake.rb
+++ b/lib/voxpupuli/acceptance/rake.rb
@@ -1,5 +1,4 @@
 begin
-  require 'puppetlabs_spec_helper/tasks/beaker'
   # Fixtures can be needed because of spec_prep
   require 'puppetlabs_spec_helper/tasks/fixtures'
 rescue LoadError

--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rbnacl-libsodium'
   s.add_runtime_dependency 'serverspec'
   s.add_runtime_dependency 'winrm'
+  s.add_development_dependency 'puppetlabs_spec_helper', '>= 1.2.0'
 end


### PR DESCRIPTION
We require the spec_prep task from puppetlabs_spec_helper in our CI
environment.