### PR TITLE
cleanup release CI job; publish to github packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,31 @@
+---
 name: Release
 
 on:
-  create:
-    ref_type: tag
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.repository == 'voxpupuli/voxpupuli-acceptance'
+    if: github.repository_owner == 'voxpupuli'
     steps:
       - uses: actions/checkout@v2
-      - name: Install Ruby 2.7
+      - name: Install Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - name: Build gem
         run: gem build *.gemspec
-      - name: Publish gem
+      - name: Publish gem to rubygems.org
         run: gem push *.gem
         env:
           GEM_HOST_API_KEY: '${{ secrets.RUBYGEMS_AUTH_TOKEN }}'
+      - name: Setup GitHub packages access
+        run: |
+          mkdir -p ~/.gem
+          echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+      - name: Publish gem to GitHub packages
+        run: gem push --key github --host https://rubygems.pkg.github.com/voxpupuli *.gem


### PR DESCRIPTION
that's the usual config we have on other gems as well (just that it now uses Ruby 3.1)