### PR TITLE
Add a GitHub Action formatter to rspec

### DIFF
--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -66,6 +66,10 @@ def configure_beaker(modules: :metadata, &block)
 end
 
 RSpec.configure do |c|
+  if ENV['GITHUB_ACTIONS'] == 'true'
+    c.formatter = 'RSpec::Github::Formatter'
+  end
+
   # Fact handling
   c.add_setting :suite_configure_facts_from_env, default: true
 

--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker-vagrant'
   s.add_runtime_dependency 'puppet-modulebuilder', '~> 0.1'
   s.add_runtime_dependency 'rake'
+  s.add_runtime_dependency 'rspec-github', '~> 2.0'
   s.add_runtime_dependency 'serverspec'
   s.add_runtime_dependency 'winrm'
   s.add_development_dependency 'puppetlabs_spec_helper', '>= 1.2.0'


### PR DESCRIPTION
It's possible to get inline annotations when running in GitHub Actions using the [rspec-github](https://drieam.github.io/rspec-github/) formatter. This means it's easier to find out why an acceptance test failed.

This is the acceptance test equivalent to https://github.com/puppetlabs/puppetlabs_spec_helper/pull/353.