### PR TITLE
puppetlabs_spec_helper: require 4.x and newer

### DIFF
--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rspec-github', '~> 2.0'
   s.add_runtime_dependency 'serverspec'
   s.add_runtime_dependency 'winrm'
-  s.add_development_dependency 'puppetlabs_spec_helper', '>= 1.2.0'
+  s.add_development_dependency 'puppetlabs_spec_helper', '>= 4.0.0'
 end


### PR DESCRIPTION
version 3 defines the beaker rake task. beaker-rspec defines that as well, and that's the one we want to use. We need to ensure that we load puppetlabs_spec_helper in version 4 (which doesn't have the beaker rake task). Otherwise we end up with two tasks. Calling it will run both which in turn will run all tests twice.