### PR TITLE
Rename example modules to be valid on the forge

### DIFF
--- a/examples/defaults_basic_dependency/metadata.json
+++ b/examples/defaults_basic_dependency/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "voxpupuli_acceptance_tests-defaults_basic_dependency",
+  "name": "voxpupuliacceptancetests-defaults_basic_dependency",
   "version": "0.0.1",
   "author": "Vox Pupuli",
   "license": "Apache-2.0",

--- a/examples/defaults_facts/metadata.json
+++ b/examples/defaults_facts/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "voxpupuli_acceptance_tests-defaults_facts",
+  "name": "voxpupuliacceptancetests-defaults_facts",
   "version": "0.0.1",
   "author": "Vox Pupuli",
   "license": "Apache-2.0",

--- a/examples/defaults_fixtures/metadata.json
+++ b/examples/defaults_fixtures/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "voxpupuli_acceptance_tests-defaults_fixtures",
+  "name": "voxpupuliacceptancetests-defaults_fixtures",
   "version": "0.0.1",
   "author": "Vox Pupuli",
   "license": "Apache-2.0",

--- a/examples/defaults_no_dependencies/metadata.json
+++ b/examples/defaults_no_dependencies/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "voxpupuli_acceptance_tests-defaults_no_dependencies",
+  "name": "voxpupuliacceptancetests-defaults_no_dependencies",
   "version": "0.0.1",
   "author": "Vox Pupuli",
   "license": "Apache-2.0",


### PR DESCRIPTION
When using `puppet module install /path/to/module.tar.gz` it calls the forge with a search for the particular module. That returns a HTTP 400 Bad Request.

While metadata-json-lint does accept the author name voxpupuli_acceptance_tests, the forge does not.