### PR TITLE
Make puppet agent installation configureable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Other common environment variables:
 * `BEAKER_DESTROY` can be set to `no` to avoid destroying the box after completion. Useful to inspect failures. Another common value is `onpass` which deletes it only when the tests pass.
 * `BEAKER_PROVISION` can be set to `no` to reuse a box. Note that the box must exist already. See `BEAKER_DESTROY`
 * `BEAKER_SETFILE` is used to point to a setfile containing definitions. To avoid storing large YAML files in all repositories, [beaker-hostgenerator](https://github.com/voxpupuli/beaker-hostgenerator) is used to generate them on the fly when the file is not present.
+* `BEAKER_PROVISION_PUPPET` when set to `yes` (which is the default), `puppet` will be installed. This can be used in combination with `BEAKER_PROVISON`. Set `BEAKER_PROVSION=yes` and `BEAKER_PROVISON_PUPPET=no` to spin up a new instance but assume puppet is already installed. This is helpful if you test with your own images or in isolated environments where the instance cannot reach the puppet.com RPM/Deb mirrors.
 
 Since it's still plain [RSpec](https://rspec.info/), it is also possible to call an individual test file:
 

--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -4,6 +4,7 @@ def configure_beaker(modules: :metadata, &block)
   collection = ENV['BEAKER_PUPPET_COLLECTION'] || 'puppet'
   ENV['BEAKER_debug'] ||= 'true'
   ENV['BEAKER_HYPERVISOR'] ||= 'docker'
+  ENV['BEAKER_PROVISION_PUPPET'] ||= 'yes'
 
   # On Ruby 3 this doesn't appear to matter but on Ruby 2 beaker-hiera must be
   # included before beaker-rspec so Beaker::DSL is final
@@ -14,10 +15,18 @@ def configure_beaker(modules: :metadata, &block)
   require_relative 'fixtures' if modules == :fixtures
 
   unless ENV['BEAKER_provision'] == 'no'
-    block_on hosts, run_in_parallel: true do |host|
-      BeakerPuppetHelpers::InstallUtils.install_puppet_release_repo_on(host, collection)
-      package_name = BeakerPuppetHelpers::InstallUtils.puppet_package_name(host)
-      host.install_package(package_name)
+    if ENV['BEAKER_PROVISION_PUPPET'] == 'yes'
+      block_on hosts, run_in_parallel: true do |host|
+        BeakerPuppetHelpers::InstallUtils.install_puppet_release_repo_on(host, collection)
+        package_name = BeakerPuppetHelpers::InstallUtils.puppet_package_name(host)
+        host.install_package(package_name)
+      end
+    else
+      block_on hosts, run_in_parallel: true do |host|
+        # by default, puppet-agent creates /etc/profile.d/puppet-agent.sh which adds /opt/puppetlabs/bin to PATH
+        # in our non-interactive ssh sessions we manipulate PATH in ~/.ssh/environment, we need to do this step here as well
+        host.add_env_var('PATH', '/opt/puppetlabs/bin')
+      end
     end
   end
 


### PR DESCRIPTION
when `BEAKER_provision_puppet`  is set to `yes` (which is the default), `puppet` will be installed. This can be used in combination with `BEAKER_provision`. Set `BEAKER_provision=yes` and `BEAKER_provison_puppet=no` to spin up a new instance but assume puppet is already installed. This is helpful if you test with your own images or in isolated environments where the instance cannot reach the puppet.com RPM/Deb mirrors.