### PR TITLE
README.md: Switch beaker env vars to uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ BEAKER_setfile=centos7-64 bundle exec rake beaker
 Other common environment variables:
 
 * `BEAKER_HYPERVISOR` defaults to `docker`, can be set to `vagrant_libvirt` or `vagrant` (using [VirtualBox](https://www.virtualbox.org/))
-* `BEAKER_destroy` can be set to `no` to avoid destroying the box after completion. Useful to inspect failures. Another common value is `onpass` which deletes it only when the tests pass.
-* `BEAKER_provision` can be set to `no` to reuse a box. Note that the box must exist already. See `BEAKER_destroy`
-* `BEAKER_setfile` is used to point to a setfile containing definitions. To avoid storing large YAML files in all repositories, [beaker-hostgenerator](https://github.com/voxpupuli/beaker-hostgenerator) is used to generate them on the fly when the file is not present.
+* `BEAKER_DESTROY` can be set to `no` to avoid destroying the box after completion. Useful to inspect failures. Another common value is `onpass` which deletes it only when the tests pass.
+* `BEAKER_PROVISION` can be set to `no` to reuse a box. Note that the box must exist already. See `BEAKER_DESTROY`
+* `BEAKER_SETFILE` is used to point to a setfile containing definitions. To avoid storing large YAML files in all repositories, [beaker-hostgenerator](https://github.com/voxpupuli/beaker-hostgenerator) is used to generate them on the fly when the file is not present.
 
 Since it's still plain [RSpec](https://rspec.info/), it is also possible to call an individual test file:
 
 ```bash
-BEAKER_setfile=centos7-64 bundle exec rspec spec/acceptance/my_test.rb
+BEAKER_SETFILE=centos7-64 bundle exec rspec spec/acceptance/my_test.rb
 ```
 
 ## Hypervisors


### PR DESCRIPTION
The uppercase names are supported since beaker-rspec 8. That's the version we depend on. See:
https://github.com/voxpupuli/beaker-rspec/commit/7b7edb58fbf3b7c353648d8960c5b593f033ea64