### PR TITLE
Support the preinstalled BEAKER_PUPPET_COLLECTION

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Other common environment variables:
 * `BEAKER_DESTROY` can be set to `no` to avoid destroying the box after completion. Useful to inspect failures. Another common value is `onpass` which deletes it only when the tests pass.
 * `BEAKER_PROVISION` can be set to `no` to reuse a box. Note that the box must exist already. See `BEAKER_DESTROY`
 * `BEAKER_SETFILE` is used to point to a setfile containing definitions. To avoid storing large YAML files in all repositories, [beaker-hostgenerator](https://github.com/voxpupuli/beaker-hostgenerator) is used to generate them on the fly when the file is not present.
-* `BEAKER_PUPPET_COLLECTION` defines the puppet collection that will be configured, defaults to `puppet`. When set to `none`, no repository will be configured.
+* `BEAKER_PUPPET_COLLECTION` defines the puppet collection that will be configured, defaults to `puppet`. When set to `none`, no repository will be configured and distro package naming is assumed. When set to `preinstalled`, it assumes the OS is already set up with a collection but it still ensures `puppet-agent` is installed.
 
 Since it's still plain [RSpec](https://rspec.info/), it is also possible to call an individual test file:
 

--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -15,10 +15,10 @@ def configure_beaker(modules: :metadata, &block)
 
   unless ENV['BEAKER_PROVISION'] == 'no'
     block_on hosts, run_in_parallel: true do |host|
-      if (has_aio = collection != 'none')
+      unless %w[none preinstalled].include?(collection)
         BeakerPuppetHelpers::InstallUtils.install_puppet_release_repo_on(host, collection)
       end
-      package_name = BeakerPuppetHelpers::InstallUtils.puppet_package_name(host, prefer_aio: has_aio)
+      package_name = BeakerPuppetHelpers::InstallUtils.puppet_package_name(host, prefer_aio: collection != 'none')
       host.install_package(package_name)
 
       # by default, puppet-agent creates /etc/profile.d/puppet-agent.sh which adds /opt/puppetlabs/bin to PATH


### PR DESCRIPTION
This special case is where an image already has the repositories set up to consume a Puppet collection, like when you consume it via a local mirror. It still ensures the Puppet package with the AIO naming is installed (so `puppet-agent`).

Entirely untested right now.