### PR TITLE
Avoid using legacy facts with beaker-hiera

### DIFF
--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -80,7 +80,7 @@ RSpec.configure do |c|
   c.add_setting :suite_hiera, default: true
   c.add_setting :suite_hiera_data_dir, default: File.join('spec', 'acceptance', 'hieradata')
   c.add_setting :suite_hiera_hierachy, default: [
-    'fqdn/%{fqdn}.yaml',
+    'fqdn/%{networking.fqdn}.yaml',
     'os/%{os.family}/%{os.release.major}.yaml',
     'os/%{os.family}.yaml',
     'common.yaml',


### PR DESCRIPTION
The fqdn fact is no longer supported in Puppet 8, so this switches over to the structured fact.