### PR TITLE
Use beaker-hiera 1.x with hiera.yaml version 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,22 @@ RSpec.configure do |c|
   c.suite_hiera = true
   c.suite_hiera_data_dir = File.join('spec', 'acceptance', 'hieradata')
   c.suite_hiera_hierachy = [
-    'fqdn/%{fqdn}.yaml',
-    'os/%{os.family}/%{os.release.major}.yaml',
-    'os/%{os.family}.yaml',
-    'common.yaml',
+    {
+      name: "Per-node data",
+      path: 'fqdn/%{facts.networking.fqdn}.yaml',
+    },
+    {
+      name: 'OS family version data',
+      path: 'family/%{facts.os.family}/%{facts.os.release.major}.yaml',
+    },
+    {
+      name: 'OS family data',
+      path: 'family/%{facts.os.family}.yaml',
+    },
+    {
+      name: 'Common data',
+      path: 'common.yaml',
+    },
   ]
 end
 ```

--- a/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
+++ b/lib/voxpupuli/acceptance/spec_helper_acceptance.rb
@@ -81,10 +81,22 @@ RSpec.configure do |c|
   c.add_setting :suite_hiera, default: true
   c.add_setting :suite_hiera_data_dir, default: File.join('spec', 'acceptance', 'hieradata')
   c.add_setting :suite_hiera_hierachy, default: [
-    'fqdn/%{networking.fqdn}.yaml',
-    'os/%{os.family}/%{os.release.major}.yaml',
-    'os/%{os.family}.yaml',
-    'common.yaml',
+    {
+      name: "Per-node data",
+      path: 'fqdn/%{facts.networking.fqdn}.yaml',
+    },
+    {
+      name: 'OS family version data',
+      path: 'family/%{facts.os.family}/%{facts.os.release.major}.yaml',
+    },
+    {
+      name: 'OS family data',
+      path: 'family/%{facts.os.family}.yaml',
+    },
+    {
+      name: 'Common data',
+      path: 'common.yaml',
+    },
   ]
 
   # Node setup

--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bcrypt_pbkdf', '~> 1.1'
   s.add_runtime_dependency 'beaker', '>= 4.33', '< 6'
   s.add_runtime_dependency 'beaker-docker', '~> 2.1'
-  s.add_runtime_dependency 'beaker-hiera', '~> 0.4'
+  s.add_runtime_dependency 'beaker-hiera', '~> 1.0'
   s.add_runtime_dependency 'beaker-hostgenerator', '~> 2.2'
   s.add_runtime_dependency 'beaker_puppet_helpers', '~> 1.0'
   s.add_runtime_dependency 'beaker-rspec', '~> 8.0', '>= 8.0.1'


### PR DESCRIPTION
The beaker-hiera 1.x release updates the suite configuration to version 5. This avoids a deprecation warning and Puppet 8 reportedly also dropped version 3.

Technically this would be a breaking change, but I have a feeling that overriding the hierachy is used very little.