### PR TITLE
Require beaker_puppet_helpers 1.3+ for bolt_supported?

### DIFF
--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker-docker', '~> 2.1'
   s.add_runtime_dependency 'beaker-hiera', '~> 1.0'
   s.add_runtime_dependency 'beaker-hostgenerator', '~> 2.2'
-  s.add_runtime_dependency 'beaker_puppet_helpers', '~> 1.0'
+  s.add_runtime_dependency 'beaker_puppet_helpers', '~> 1.3'
   s.add_runtime_dependency 'beaker-rspec', '~> 8.0', '>= 8.0.1'
   s.add_runtime_dependency 'beaker-vagrant', '~> 1.2'
   s.add_runtime_dependency 'puppet-modulebuilder', '~> 1.0'


### PR DESCRIPTION
Version 1.3.0 comes with a new `bolt_supported?` helper. Puppet modules don't directly depend on `beaker_puppet_helpers`, so by requiring it here we can give a guarantee. Then the Puppet module can depend on a new enough `voxpupuli-acceptance`.