### PR TITLE
Support none and preinstalled collections again

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other common environment variables:
 * `BEAKER_DESTROY` can be set to `no` to avoid destroying the box after completion. Useful to inspect failures. Another common value is `onpass` which deletes it only when the tests pass.
 * `BEAKER_PROVISION` can be set to `no` to reuse a box. Note that the box must exist already. See `BEAKER_DESTROY`. Known to be broken with [beaker-docker](https://github.com/voxpupuli/beaker-docker).
 * `BEAKER_SETFILE` is used to point to a setfile containing definitions. To avoid storing large YAML files in all repositories, [beaker-hostgenerator](https://github.com/voxpupuli/beaker-hostgenerator) is used to generate them on the fly when the file is not present.
-* `BEAKER_PUPPET_COLLECTION` defines the puppet collection that will be configured, defaults to `puppet`. When set to `none`, no repository will be configured and distro package naming is assumed. When set to `preinstalled`, it assumes the OS is already set up with a collection but it still ensures `puppet-agent` is installed.
+* `BEAKER_PUPPET_COLLECTION` defines the puppet collection that will be configured, defaults to `puppet`. When set to `none`, no repository will be configured and distro package naming is assumed. When set to `preinstalled`, it assumes the OS is already set up with a collection and Puppet/OpenVox package.
 * `BEAKER_PUPPET_PACKAGE_NAME` optional env var to set the puppet agent package name. If not set, the package name will be determined using [puppet_metadata](https://github.com/voxpupuli/puppet_metadata#puppet_metadata).
 
 Since it's still plain [RSpec](https://rspec.info/), it is also possible to call an individual test file:

--- a/voxpupuli-acceptance.gemspec
+++ b/voxpupuli-acceptance.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'beaker-docker', '~> 2.1'
   s.add_dependency 'beaker-hiera', '~> 1.0'
   s.add_dependency 'beaker-hostgenerator', '~> 2.2'
-  s.add_dependency 'beaker_puppet_helpers', '~> 2.1'
+  s.add_dependency 'beaker_puppet_helpers', '~> 2.2'
   s.add_dependency 'beaker-rspec', '~> 8.0', '>= 8.0.1'
   s.add_dependency 'beaker-vagrant', '~> 1.2'
   s.add_dependency 'puppet-modulebuilder', '~> 2.0', '>= 2.0.2'


### PR DESCRIPTION
When OpenVox support was added it didn't take none and preinstalled. beaker_puppet_helpers 2.2 introduced support for the none collection so that logic is pushed into the helper.

This is a change where preinstalled now also requires the package itself to be preinstalled, rather than just the repository.

Fixes: d89ef932b74a ("Implement OpenVox support")
