### PR TITLE
Add new shared example with debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ describe 'myclass' do
 end
 ```
 
+### An idempotent resource with debug
+
+This is the same as above, but it runs `puppet apply --debug...`
+
+```ruby
+describe 'myclass' do
+  it_behaves_like 'an idempotent resource with debug' do
+    let(:manifest) do
+      <<-PUPPET
+      include myclass
+      PUPPET
+    end
+  end
+end
+```
+
 ### Examples
 
 In modules there's the convention to have an examples directory. It's actually great to test these in acceptance. For this a shared example is available:

--- a/lib/voxpupuli/acceptance/examples.rb
+++ b/lib/voxpupuli/acceptance/examples.rb
@@ -12,6 +12,18 @@ shared_examples 'an idempotent resource' do |host|
   end
 end
 
+shared_examples 'an idempotent resource with debug' do |host|
+  host ||= default
+
+  it 'applies with no errors' do
+    apply_manifest_on(host, manifest, catch_failures: true, debug: true)
+  end
+
+  it 'applies a second time without changes' do
+    apply_manifest_on(host, manifest, catch_changes: true, debug: true)
+  end
+end
+
 shared_examples 'the example' do |name, host|
   include_examples 'an idempotent resource', host do
     let(:manifest) do


### PR DESCRIPTION
This is the same as our existing shared example, but it runs `puppet apply --debug...`